### PR TITLE
Add a global killswitch

### DIFF
--- a/app/fetcher/src/PullRequestUtils.hs
+++ b/app/fetcher/src/PullRequestUtils.hs
@@ -25,6 +25,7 @@ import qualified Sql.Read.PullRequests      as ReadPullRequests
 import qualified Sql.Read.Types             as SqlReadTypes
 import qualified Sql.Write                  as SqlWrite
 
+isPostingEnabledGlobally = False
 
 handleCommentPostingOptOut conn access_token pr_number f = do
   pr_author <- fetchAndCachePrAuthor conn access_token pr_number
@@ -32,13 +33,16 @@ handleCommentPostingOptOut conn access_token pr_number f = do
   can_post_comments <- ExceptT $
     ReadPullRequests.canPostPullRequestComments conn pr_author
 
-  if can_post_comments
-    then f
-    else ExceptT $ do
-      runReaderT (SqlWrite.recordBlockedPRCommentPosting pr_number) $
-        SqlReadTypes.AuthConnection conn pr_author
-
+  if not isPostingEnabledGlobally
+    then ExceptT $ do
       return $ Right (pr_number, Nothing)
+    else if can_post_comments
+      then f
+      else ExceptT $ do
+        runReaderT (SqlWrite.recordBlockedPRCommentPosting pr_number) $
+          SqlReadTypes.AuthConnection conn pr_author
+
+        return $ Right (pr_number, Nothing)
 
 
 fetchAndCachePrAuthor ::

--- a/app/fetcher/src/StatusUpdate.hs
+++ b/app/fetcher/src/StatusUpdate.hs
@@ -85,6 +85,8 @@ import qualified StatusUpdateTypes
 import qualified UnmatchedBuilds
 import qualified Webhooks
 
+isPostingEnabledGlobally :: Bool
+isPostingEnabledGlobally = False
 
 -- | 2 minutes
 statementTimeoutSeconds :: Integer
@@ -849,17 +851,21 @@ wipeCommentForUpdatedPr
     pr_number
     new_pr_head_commit@(Builds.RawCommit sha1_text) = do
 
-  updateCommentOrFallback
-    access_token
-    owned_repo
-    conn
-    new_pr_head_commit
-    True
-    (CommentRenderCommon.NewPrCommentPayload [[middle_sections]] True True)
-    pr_number
-    previous_pr_comment
+  if isPostingEnabledGlobally
+    then do
+      updateCommentOrFallback
+        access_token
+        owned_repo
+        conn
+        new_pr_head_commit
+        True
+        (CommentRenderCommon.NewPrCommentPayload [[middle_sections]] True True)
+        pr_number
+        previous_pr_comment
 
-  return ()
+      return ()
+    else do
+      return ()
   where
     middle_sections = M.italic $ T.unwords [
         "Commit"

--- a/app/fetcher/src/StatusUpdate.hs
+++ b/app/fetcher/src/StatusUpdate.hs
@@ -665,7 +665,7 @@ postCommitSummaryStatusInner
     PullRequestUtils.handleCommentPostingOptOut conn access_token pr_number $ do
 
       maybe_comment_revision_id <- case maybe_previous_pr_comment of
-        Nothing -> Just <$> postInitialComment
+        Nothing -> postInitialComment
           access_token
           owned_repo
           conn
@@ -706,7 +706,7 @@ conditionallyPostIfNovelComment
     D.debugStr "New comment would be the same as the last one! Not posting."
     return Nothing
 
-  else Just <$> updateCommentOrFallback
+  else updateCommentOrFallback
     access_token
     owned_repo
     conn
@@ -739,7 +739,7 @@ postInitialComment ::
   -> Bool -- ^ was new push
   -> CommentRenderCommon.PrCommentPayload
   -> Builds.PullRequestNumber
-  -> ExceptT LT.Text IO CommentRenderCommon.CommentRevisionId
+  -> ExceptT LT.Text IO (Maybe CommentRenderCommon.CommentRevisionId)
 postInitialComment
     access_token
     owned_repo
@@ -749,20 +749,24 @@ postInitialComment
     pr_comment_payload
     pr_number = do
 
-  comment_post_result <- ExceptT $ ApiPost.postPullRequestComment
-    access_token
-    owned_repo
-    pr_number
-    pr_comment_text
+  if isPostingEnabledGlobally
+    then do
+      comment_post_result <- ExceptT $ ApiPost.postPullRequestComment
+        access_token
+        owned_repo
+        pr_number
+        pr_comment_text
 
-  liftIO $ SqlWrite.insertPostedGithubComment
-    conn
-    owned_repo
-    sha1
-    pr_number
-    was_new_push
-    pr_comment_payload
-    comment_post_result
+      liftIO $ Just <$> SqlWrite.insertPostedGithubComment
+        conn
+        owned_repo
+        sha1
+        pr_number
+        was_new_push
+        pr_comment_payload
+        comment_post_result
+    else do
+        return Nothing
 
   where
     pr_comment_text = CommentRender.generateCommentMarkdown
@@ -781,7 +785,7 @@ updateCommentOrFallback ::
   -> CommentRenderCommon.PrCommentPayload
   -> Builds.PullRequestNumber
   -> ReadPullRequests.PostedPRComment
-  -> ExceptT LT.Text IO CommentRenderCommon.CommentRevisionId
+  -> ExceptT LT.Text IO (Maybe CommentRenderCommon.CommentRevisionId)
 updateCommentOrFallback
     access_token
     owned_repo
@@ -800,7 +804,7 @@ updateCommentOrFallback
 
   case either_comment_update_result of
     Right comment_update_result ->
-      liftIO $ SqlWrite.modifyPostedGithubComment
+      liftIO $ Just <$> SqlWrite.modifyPostedGithubComment
         conn
         sha1
         was_new_push


### PR DESCRIPTION
We can merge this when we're ready to tentatively launch the FB-internal version of Dr. CI.

If we end up needing to re-enable the AWS version we can either revert this PR or change `isPostingEnabledGlobally` to `True`

Test plan:
???
It compiled?